### PR TITLE
Reduce Supabase calls with localStorage cache

### DIFF
--- a/src/app/providers/ReactQueryProvider.tsx
+++ b/src/app/providers/ReactQueryProvider.tsx
@@ -4,7 +4,16 @@ import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 
 export const ReactQueryProvider = ({ children }: { children: React.ReactNode }) => {
-  const [queryClient] = useState(() => new QueryClient())
+  const [queryClient] = useState(() => new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: Infinity,
+        cacheTime: Infinity,
+        refetchOnWindowFocus: false,
+        refetchOnMount: false,
+      }
+    }
+  }))
 
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,28 @@
+export function getCachedData<T>(key: string): T | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const value = localStorage.getItem(key)
+    if (!value) return null
+    return JSON.parse(value) as T
+  } catch {
+    return null
+  }
+}
+
+export function setCachedData<T>(key: string, data: T): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(key, JSON.stringify(data))
+  } catch {
+    // ignore
+  }
+}
+
+export function removeCachedData(key: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.removeItem(key)
+  } catch {
+    // ignore
+  }
+}

--- a/src/services/goal.ts
+++ b/src/services/goal.ts
@@ -1,6 +1,7 @@
 import { GoalArraySchema, GoalSchema, PartialGoalSchema } from '@/lib/validators/goal'
 import { Goal, Prisma } from '@prisma/client'
 import { Status } from '@/app/types/types'
+import { getCachedData, setCachedData } from '@/lib/cache'
 
 const create = async (data: Prisma.GoalCreateInput): Promise<Goal> => {
   const parsedData = { ...GoalSchema.parse(data), planId: data.plan.connect!.id! }
@@ -14,6 +15,10 @@ const create = async (data: Prisma.GoalCreateInput): Promise<Goal> => {
   if (!response.ok) {
     throw new Error('Failed to create goal')
   }
+
+  const cacheKey = `goals:${parsedData.planId}`
+  const cached = getCachedData<Goal[]>(cacheKey) || []
+  setCachedData(cacheKey, [...cached, parsedData as Goal])
 
   return parsedData
 }
@@ -30,10 +35,21 @@ const createBulk = async (goals: Prisma.GoalCreateManyInput[]): Promise<Goal[]> 
     throw new Error('Failed to create goals')
   }
 
+  const planId = goals[0]?.planId
+  if (planId) {
+    const cacheKey = `goals:${planId}`
+    const cached = getCachedData<Goal[]>(cacheKey) || []
+    setCachedData(cacheKey, [...cached, ...parsedData as Goal[]])
+  }
+
   return parsedData
 }
 
 const get = async (id: string): Promise<Goal | null> => {
+  const cacheKey = `goal:${id}`
+  const cached = getCachedData<Goal>(cacheKey)
+  if (cached) return cached
+
   const response = await fetch(`/api/goal/${id}`)
   if (!response.ok) {
     console.error(`Failed to fetch goal ${id} from remote:`, response.status)
@@ -41,14 +57,20 @@ const get = async (id: string): Promise<Goal | null> => {
   }
 
   const remoteGoal = await response.json()
+  if (remoteGoal) setCachedData(cacheKey, remoteGoal)
   return remoteGoal
 }
 
 const getByPlanId = async (planId: string, status = Status.ACTIVE): Promise<Goal[]> => {
+  const cacheKey = `goals:${planId}`
+  const cached = getCachedData<Goal[]>(cacheKey)
+  if (cached) return cached
+
   const response = await fetch(`/api/goal?planId=${planId}&status=${status}`)
   if (!response.ok) return []
 
   const remoteGoals = await response.json()
+  setCachedData(cacheKey, remoteGoals)
   return remoteGoals
 }
 
@@ -66,6 +88,17 @@ const update = async (id: string, goal: Prisma.GoalUpdateInput): Promise<Partial
     throw new Error('Failed to update goal')
   }
 
+  const cacheKey = `goal:${id}`
+  const data = { ...(getCachedData<Goal>(cacheKey) || {}), ...parsedData } as Goal
+  setCachedData(cacheKey, data)
+  if (goal.planId) {
+    const listKey = `goals:${goal.planId}`
+    const list = getCachedData<Goal[]>(listKey)
+    if (list) {
+      setCachedData(listKey, list.map(g => g.id === id ? { ...g, ...parsedData } as Goal : g))
+    }
+  }
+
   return parsedData
 }
 
@@ -76,6 +109,17 @@ const deleteItem = async (id: string): Promise<void> => {
 
   if (!response.ok) {
     throw new Error('Failed to delete goal')
+  }
+
+  const cacheKey = `goal:${id}`
+  const goal = getCachedData<Goal>(cacheKey)
+  setCachedData(cacheKey, null as any)
+  if (goal?.planId) {
+    const listKey = `goals:${goal.planId}`
+    const list = getCachedData<Goal[]>(listKey)
+    if (list) {
+      setCachedData(listKey, list.filter(g => g.id !== id))
+    }
   }
 }
 

--- a/src/services/plan.ts
+++ b/src/services/plan.ts
@@ -1,11 +1,21 @@
 import { PartialPlanSchema, PlanSchema } from '@/lib/validators/plan'
 import { Plan, Prisma } from '@prisma/client'
+import { getCachedData, setCachedData, removeCachedData } from '@/lib/cache'
 
 const getByUserId = async (userId: string): Promise<Plan | null> => {
+  const cacheKey = `plan:${userId}`
+  const cached = getCachedData<Plan>(cacheKey)
+  if (cached) {
+    return cached
+  }
+
   const response = await fetch(`/api/plan?userId=${userId}`, {
     method: 'GET',
   })
   const remotePlan = await response.json()
+  if (response.ok && remotePlan) {
+    setCachedData(cacheKey, remotePlan)
+  }
   return remotePlan
 }
 
@@ -22,24 +32,40 @@ const create = async (data: Prisma.PlanCreateInput): Promise<Plan> => {
     throw new Error('Failed to create plan')
   }
 
+  setCachedData(`plan:${parsedData.user.connect!.id}`, parsedData as Plan)
+
   return parsedData
 }
 
 const get = async (id: string): Promise<Plan | null> => {
+  const cacheKey = `plan:id:${id}`
+  const cached = getCachedData<Plan>(cacheKey)
+  if (cached) return cached
+
   const response = await fetch(`/api/plan/${id}`)
   if (!response.ok) {
     return null
   }
 
   const remotePlan = await response.json()
+  if (remotePlan) {
+    setCachedData(cacheKey, remotePlan)
+  }
   return remotePlan
 }
 
 const getAll = async (userId: string): Promise<Plan[]> => {
+  const cacheKey = `plans:${userId}`
+  const cached = getCachedData<Plan[]>(cacheKey)
+  if (cached) return cached
+
   const response = await fetch(`/api/plan/all?userId=${userId}`, {
     method: 'GET',
   })
   const remotePlans = await response.json()
+  if (response.ok) {
+    setCachedData(cacheKey, remotePlans)
+  }
   return remotePlans
 }
 
@@ -56,6 +82,9 @@ const update = async (id: string, plan: Prisma.PlanUpdateInput): Promise<Partial
     throw new Error('Failed to update plan')
   }
 
+  const cacheKey = `plan:id:${id}`
+  const data = { ...(getCachedData<Plan>(cacheKey) || {}), ...parsedData } as Plan
+  setCachedData(cacheKey, data)
   return parsedData
 }
 


### PR DESCRIPTION
## Summary
- introduce local cache helpers
- persist API responses in localStorage for plans, goals, strategies and indicators
- customise React Query to avoid automatic refetching

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: npm registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6875484f92d8833281e5e402bc4c0cb7