### PR TITLE
Fix selectors inside GoalDialog

### DIFF
--- a/src/components/GoalManager/FrequencySelector.tsx
+++ b/src/components/GoalManager/FrequencySelector.tsx
@@ -19,7 +19,7 @@ export const FrequencySelector = ({ frequency = DEFAULT_FREQUENCY, setFrequency,
   }
 
   return (
-    <div className="bg-white border border-gray-200 rounded-md shadow-sm FREQUENCY_SELECTOR">
+    <div className="relative z-50 bg-white border border-gray-200 rounded-md shadow-sm FREQUENCY_SELECTOR">
       <SelectRoot
         open
         collection={COLLECTION}
@@ -33,7 +33,7 @@ export const FrequencySelector = ({ frequency = DEFAULT_FREQUENCY, setFrequency,
         <SelectTrigger clearable>
           <SelectValueText placeholder="Frequency" />
         </SelectTrigger>
-        <SelectContent onMouseLeave={onFocusOutside} className="max-h-64">
+        <SelectContent portalled={false} onMouseLeave={onFocusOutside} className="max-h-64">
           {COLLECTION.items.map((item) => (
             <SelectItem
               item={item}

--- a/src/components/GoalManager/WeeksSelector.tsx
+++ b/src/components/GoalManager/WeeksSelector.tsx
@@ -26,7 +26,7 @@ export const WeeksSelector = ({ weeks, setWeeks, onFocusOutside }: WeeksSelector
   }
 
   return (
-    <div className="bg-white border border-gray-200 rounded-md shadow-sm">
+    <div className="relative z-50 bg-white border border-gray-200 rounded-md shadow-sm">
       <SelectRoot
         open
         multiple
@@ -43,6 +43,7 @@ export const WeeksSelector = ({ weeks, setWeeks, onFocusOutside }: WeeksSelector
           <SelectValueText placeholder="Weeks" />
         </SelectTrigger>
         <SelectContent
+          portalled={false}
           onMouseLeave={onFocusOutside}
           className="max-h-64 overflow-auto"
         >


### PR DESCRIPTION
## Summary
- keep FrequencySelector dropdown within dialog
- keep WeeksSelector dropdown within dialog

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68768ea68d048332890bdb220af431d2