### PR TITLE
Fix auth middleware failing when Supabase fetch errors

### DIFF
--- a/src/app/util/supabase/middleware.ts
+++ b/src/app/util/supabase/middleware.ts
@@ -35,7 +35,12 @@ export async function updateSession(request: NextRequest) {
 
   const {
     data: { user },
+    error: userError,
   } = await supabase.auth.getUser()
+
+  if (userError) {
+    console.error('Error fetching user in middleware:', userError.message)
+  }
 
 
   const { pathname } = request.nextUrl
@@ -46,7 +51,7 @@ export async function updateSession(request: NextRequest) {
   const isPlanNew = pathname === '/plan/new'
 
   // 3) If no user → only allow auth pages
-  if (!user && !isAuthPage) {
+  if (!user && !isAuthPage && !userError) {
     console.log('No user, redirecting to login', request.nextUrl.pathname)
     return NextResponse.redirect(new URL('/login', request.url))
   }


### PR DESCRIPTION
## Summary
- avoid redirecting to login when Supabase fails to fetch the user
- log middleware auth fetch errors

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6876953815788332baa5c1c876bc4b6b