### PR TITLE
optimize strategy fetching

### DIFF
--- a/src/app/plan-v2/GoalCard.tsx
+++ b/src/app/plan-v2/GoalCard.tsx
@@ -4,7 +4,7 @@ import { usePlanContext } from '@/app/providers/usePlanContext';
 import { calculateCompletionScore } from '@/app/util';
 import { Badge, Button, Card, Collapsible, Dialog, Portal } from '@chakra-ui/react';
 import { Goal } from '@prisma/client';
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { LuChevronDown, LuChevronUp, LuListChecks, LuPencil, LuTrash2 } from 'react-icons/lu';
 import { SavingSpinner } from '@/components/SavingSpinner';
 
@@ -13,7 +13,7 @@ interface GoalCardProps {
 }
 
 export function GoalCard({ goal }: GoalCardProps) {
-  const { plan, planActions, goalActions, strategyActions, indicatorActions } = usePlanContext()
+  const { goalActions, strategies } = usePlanContext()
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   // const [isStrategyDialogOpen, setIsStrategyDialogOpen] = useState(false);
@@ -21,11 +21,14 @@ export function GoalCard({ goal }: GoalCardProps) {
   // const [editedContent, setEditedContent] = useState(goal.content);
   const [isOpen, setIsOpen] = useState(false);
   const deleteGoal = goalActions.useDelete()
-  const { data: strategies = [] } = strategyActions.useGetByGoalId(goal.id)
+  const goalStrategies = useMemo(
+    () => strategies.filter((s) => s.goalId === goal.id),
+    [strategies, goal.id]
+  )
   // const { data: indicators = [] } = indicatorActions.useGetByGoalId(goal.id)
 
-  // const progress = calculateCompletionScore(strategies);
-  const strategiesCount = strategies?.length || 0;
+  // const progress = calculateCompletionScore(goalStrategies);
+  const strategiesCount = goalStrategies?.length || 0;
   // const indicatorsCount = indicators?.length || 0;
 
   const handleDeleteGoal = async () => {
@@ -67,8 +70,8 @@ export function GoalCard({ goal }: GoalCardProps) {
       </Card.Body>
 
       <Collapsible.Root open={isOpen} onOpenChange={({ open }) => setIsOpen(open)} className="px-4">
-        {/* {(strategies?.length > 0 || indicators?.length > 0) && ( */}
-        {(strategies?.length > 0) && (
+        {/* {(goalStrategies?.length > 0 || indicators?.length > 0) && ( */}
+        {(goalStrategies?.length > 0) && (
           <Collapsible.Trigger asChild>
             <Button variant="ghost" size="sm" className="flex w-full justify-center">
               {isOpen ? (
@@ -81,13 +84,13 @@ export function GoalCard({ goal }: GoalCardProps) {
         )}
 
         <Collapsible.Content className="space-y-4 pt-2">
-          {strategies?.length > 0 && (
+          {goalStrategies?.length > 0 && (
             <div className="space-y-2">
               <h4 className="text-sm font-medium flex items-center">
                 <LuListChecks className="h-3 w-3 mr-1" /> Actions
               </h4>
               <ul className="space-y-1">
-                {strategies.map(strategy => (
+                {goalStrategies.map(strategy => (
                   <li key={strategy.id} className="text-xs text-muted-foreground">
                     • {strategy.content} ({strategy.frequency}x/week)
                   </li>

--- a/src/app/providers/usePlanContext.tsx
+++ b/src/app/providers/usePlanContext.tsx
@@ -7,7 +7,7 @@ import { UseIndicatorActions, useIndicatorActions } from '@/app/hooks/useIndicat
 import { UseGoalHistoryActions, useGoalHistoryActions } from '@/app/hooks/useGoalHistoryActions'
 import { UseStrategyHistoryActions, useStrategyHistoryActions } from '@/app/hooks/useStrategyHistoryActions'
 import { UseIndicatorHistoryActions, useIndicatorHistoryActions } from '@/app/hooks/useIndicatorHistoryActions'
-import { Plan } from '@prisma/client'
+import { Plan, Strategy } from '@prisma/client'
 import { Center, Spinner } from '@chakra-ui/react'
 import { useAuth } from '@/app/providers/AuthProvider'
 
@@ -19,6 +19,8 @@ type PlanContextType = {
   goalActions: UseGoalActions
   strategyActions: UseStrategyActions
   indicatorActions: UseIndicatorActions
+
+  strategies: Strategy[]
 
   goalHistoryActions: UseGoalHistoryActions
   strategyHistoryActions: UseStrategyHistoryActions
@@ -43,11 +45,14 @@ export const PlanProvider = ({ children }: PlanTrackingProviderProps) => {
   const hasPlan = !!plan
   const hasStartedPlan = !!plan?.started
 
+  const { data: strategies = [], isLoading: strategiesLoading } =
+    strategyActions.useGetByPlanId(plan?.id as string)
+
   const goalHistoryActions = useGoalHistoryActions()
   const strategyHistoryActions = useStrategyHistoryActions()
   const indicatorHistoryActions = useIndicatorHistoryActions()
 
-  if (isLoadingPlan) {
+  if (isLoadingPlan || strategiesLoading) {
     return (
       <Center height="100vh">
         <Spinner size="xl" />
@@ -65,6 +70,8 @@ export const PlanProvider = ({ children }: PlanTrackingProviderProps) => {
         goalActions,
         strategyActions,
         indicatorActions,
+
+        strategies,
         goalHistoryActions,
         strategyHistoryActions,
         indicatorHistoryActions,

--- a/src/components/GoalManager/Strategy/StrategyList.tsx
+++ b/src/components/GoalManager/Strategy/StrategyList.tsx
@@ -6,7 +6,7 @@ import { SavingSpinner } from '@/components/SavingSpinner'
 import { Alert, Button } from '@chakra-ui/react'
 import { Strategy } from '@prisma/client'
 import cuid from 'cuid'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { GoPlus } from 'react-icons/go'
 import { useDebouncedCallback } from 'use-debounce'
 
@@ -19,9 +19,12 @@ interface StrategyListProps {
 }
 
 export function StrategyList({ goalId, planId, maxLimit, onEdit, onLoading }: StrategyListProps) {
-  const { strategyActions } = usePlanContext()
-  const { data: _strategies = [] } = strategyActions.useGetByGoalId(goalId)
-  const [strategies, setStrategies] = useState<Strategy[]>([..._strategies])
+  const { strategyActions, strategies } = usePlanContext()
+  const goalStrategies = useMemo(
+    () => strategies.filter((s) => s.goalId === goalId),
+    [strategies, goalId]
+  )
+  const [strategies, setStrategies] = useState<Strategy[]>([...goalStrategies])
   const [activeStrategy, setActiveStrategy] = useState<string | null>(null)
 
   const create = strategyActions.useCreate()
@@ -89,11 +92,11 @@ export function StrategyList({ goalId, planId, maxLimit, onEdit, onLoading }: St
 
   useEffect(() => {
     setStrategies(prev => {
-      if (!prev.length) return _strategies
-      if (prev.length !== _strategies.length) return _strategies
+      if (!prev.length) return goalStrategies
+      if (prev.length !== goalStrategies.length) return goalStrategies
       return prev
     })
-  }, [_strategies.length])
+  }, [goalStrategies.length])
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
## Summary
- provide plan strategies via `PlanProvider`
- filter plan strategies per goal in `GoalCard`
- consume strategies from context in `StrategyList`

## Testing
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module '@prisma/client')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687698c63be8833285cbb1a80fecdd63