### PR TITLE
Fix goal card frequencies logic

### DIFF
--- a/src/app/dashboard-v2/GoalCard.tsx
+++ b/src/app/dashboard-v2/GoalCard.tsx
@@ -1,6 +1,6 @@
 import { Goal } from '@prisma/client';
 import WeekProgressIndicator from './WeekProgressIndicator';
-import { Box, Button, Card, Flex, Heading } from '@chakra-ui/react'
+import { Box, Button, Card, Flex, Heading, Badge } from '@chakra-ui/react'
 import { useMemo } from 'react';
 import { usePlanContext } from '@/app/providers/usePlanContext';
 
@@ -27,11 +27,25 @@ export default function GoalCard({ goal, sequence }: GoalCardProps) {
   )
 
   const handleToggleStrategy = (id: string, index: number) => {
-    console.log('toggle>>>>', id, index)
-    const updatedFrequencies = [...strategies.find(s => s.id === id)!.frequencies]
-    console.log('updatedFrequencies>>>>', updatedFrequencies)
+    const strategy = strategies.find((s) => s.id === id)
+    if (!strategy) return
+
+    let updatedFrequencies = [...strategy.frequencies]
+
+    if (!updatedFrequencies.length) {
+      updatedFrequencies = Array(7).fill(false)
+    } else if (updatedFrequencies.length < 7) {
+      updatedFrequencies = [
+        ...updatedFrequencies,
+        ...Array(7 - updatedFrequencies.length).fill(false),
+      ]
+    }
+
     updatedFrequencies[index] = !updatedFrequencies[index]
-    updateStrategy.mutate({ strategyId: id, updates: { frequencies: updatedFrequencies } })
+    updateStrategy.mutate({
+      strategyId: id,
+      updates: { frequencies: updatedFrequencies },
+    })
   }
 
   const calculateCompletionPercentage = () => {
@@ -63,10 +77,18 @@ export default function GoalCard({ goal, sequence }: GoalCardProps) {
         </Box>
         <Box display="flex" flexDirection="column" gap={6}>
           {goalStrategies.map((action) => {
+            const completedCount = action.frequencies.filter(Boolean).length
+            const reachedLimit = completedCount >= action.strategy.frequency
+
             return (
               <Box key={action.id} display="flex" flexDirection="column" gap={2}>
                 <Flex justify="space-between" align="center">
                   <Heading as="h4" size="sm">{action.strategy.content}</Heading>
+                  {reachedLimit && (
+                    <Badge colorPalette="green" borderRadius="md">
+                      Complete action
+                    </Badge>
+                  )}
                 </Flex>
                 <Flex flexWrap="wrap" gap={2}>
                   {[...Array(7).keys()].map((_, index) => {
@@ -86,6 +108,7 @@ export default function GoalCard({ goal, sequence }: GoalCardProps) {
                           minW="24px"
                           h="24px"
                           aria-label={`${isCompleted ? 'Mark as incomplete' : 'Mark as complete'} for ${dayName}`}
+                          disabled={reachedLimit}
                         >
                           {isCompleted && '✓'}
                         </Button>

--- a/src/app/dashboard-v2/GoalCard.tsx
+++ b/src/app/dashboard-v2/GoalCard.tsx
@@ -1,6 +1,6 @@
 import { Goal } from '@prisma/client';
 import WeekProgressIndicator from './WeekProgressIndicator';
-import { Box, Button, Card, Flex, Heading, Badge } from '@chakra-ui/react'
+import { Box, Button, Card, Flex, Heading, Badge, Text } from '@chakra-ui/react'
 import { useMemo } from 'react';
 import { usePlanContext } from '@/app/providers/usePlanContext';
 
@@ -49,11 +49,9 @@ export default function GoalCard({ goal, sequence }: GoalCardProps) {
   }
 
   const calculateCompletionPercentage = () => {
-    // const total = goalStrategies.reduce((acc, strategy) => {
-    //   return acc + strategy.strategy.frequency
-    // }, 0)
-
-    const total = 7 * goalStrategies.length;
+    const total = goalStrategies.reduce((acc, strategy) => {
+      return acc + strategy.strategy.frequency
+    }, 0)
 
     const completed = goalStrategies.reduce((acc, strategy) => {
       return acc + strategy.frequencies.filter(Boolean).length
@@ -84,11 +82,17 @@ export default function GoalCard({ goal, sequence }: GoalCardProps) {
               <Box key={action.id} display="flex" flexDirection="column" gap={2}>
                 <Flex justify="space-between" align="center">
                   <Heading as="h4" size="sm">{action.strategy.content}</Heading>
-                  {reachedLimit && (
-                    <Badge colorPalette="green" borderRadius="md">
-                      Complete action
-                    </Badge>
-                  )}
+                  <Badge colorPalette="green" borderRadius="md">
+                    {reachedLimit ? (
+                      'Complete action'
+                    )
+                      : (
+                        <Text as="span" colorPalette="gray.500">
+                          {completedCount}/{action.strategy.frequency}
+                        </Text>
+                      )
+                    }
+                  </Badge>
                 </Flex>
                 <Flex flexWrap="wrap" gap={2}>
                   {[...Array(7).keys()].map((_, index) => {
@@ -97,7 +101,7 @@ export default function GoalCard({ goal, sequence }: GoalCardProps) {
 
                     return (
                       <Box key={index} display="flex" flexDirection="column" alignItems="center" gap={1}>
-                        {/* <Text fontSize="xs" color="gray.500">{dayName}</Text> */}
+                        <Text fontSize="xs" color="gray.500">{dayName}</Text>
                         <Button
                           onClick={() => handleToggleStrategy(action.id, index)}
                           size="xs"


### PR DESCRIPTION
## Summary
- handle empty frequencies on dashboard goal cards
- disable action buttons when completed
- show completion badge when an action is finished

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880025125bc8332ba18d8dbcb945485