### PR TITLE
Implement dashboard-v2 improvements

### DIFF
--- a/src/app/dashboard-v2/CurrentWeekSummary.tsx
+++ b/src/app/dashboard-v2/CurrentWeekSummary.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { Box, Flex, Heading, Spinner, Text } from '@chakra-ui/react'
+import { usePlanContext } from '@/app/providers/usePlanContext'
+import { useDashboardContext } from '@/app/dashboard/dashboardContext'
+import { calculateWeekEndDate, calculateWeekStartDate, formatDate, getCurrentWeekFromStartDate } from '@/app/util'
+
+export default function CurrentWeekSummary() {
+  const { plan } = usePlanContext()
+  const { weeklyScores, isRefetching } = useDashboardContext()
+
+  if (!plan?.startDate) return null
+
+  const currentWeek = getCurrentWeekFromStartDate(plan.startDate) || 1
+  const startDate = calculateWeekStartDate(plan.startDate, currentWeek)
+  const endDate = calculateWeekEndDate(startDate)
+  const score = weeklyScores[currentWeek - 1] || 0
+
+  return (
+    <Flex justify="space-between" align="center" mb={4}>
+      <Box>
+        <Heading size="md">Week {currentWeek}</Heading>
+        <Text fontSize="sm">{formatDate(startDate)} - {formatDate(endDate)}</Text>
+      </Box>
+      <Text fontSize="md">
+        {isRefetching ? <Spinner size="xs" /> : score}/100%
+      </Text>
+    </Flex>
+  )
+}
+

--- a/src/app/dashboard-v2/page.tsx
+++ b/src/app/dashboard-v2/page.tsx
@@ -1,6 +1,10 @@
 'use client';
 import GoalCard from '@/app/dashboard-v2/GoalCard';
+import CurrentWeekSummary from '@/app/dashboard-v2/CurrentWeekSummary';
 import { usePlanContext } from '@/app/providers/usePlanContext';
+import { DashboardProvider } from '@/app/dashboard/dashboardContext';
+import { Grid } from '@chakra-ui/react';
+import { getCurrentWeekFromStartDate } from '@/app/util';
 
 export function DashboardV2() {
   const { plan, goalActions } = usePlanContext();
@@ -15,9 +19,26 @@ export function DashboardV2() {
     return <div>Loading...</div>;
   }
 
-  return <div>
-    <GoalCard goal={goals[0]} sequence={1} />
-  </div>;
+  const currentWeek = getCurrentWeekFromStartDate(plan?.startDate as Date) || 1;
+
+  return (
+    <>
+      <CurrentWeekSummary />
+      <Grid gap={6} gridTemplateColumns={{ base: '1fr', lg: '1fr 1fr' }}>
+        {goals.map((g) => (
+          <GoalCard key={g.id} goal={g} sequence={currentWeek} />
+        ))}
+      </Grid>
+    </>
+  );
 }
 
-export default DashboardV2;
+function DashboardV2WithContext() {
+  return (
+    <DashboardProvider>
+      <DashboardV2 />
+    </DashboardProvider>
+  )
+}
+
+export default DashboardV2WithContext;


### PR DESCRIPTION
## Summary
- list all goal cards in dashboard-v2
- add a weekly summary header component
- fix progress percentage calculation
- keep checkbox loading state until data refresh
- show current week progress with layout updates

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68801151846c83328ac597776ff2361a