### PR TITLE
Add habit tracker dashboard page with charts

### DIFF
--- a/src/app/plan/page.tsx
+++ b/src/app/plan/page.tsx
@@ -327,7 +327,7 @@ function PlanV2Page() {
                 View charts and trends of your indicators to see your progress over time.
               </p>
               <Button asChild colorPalette="black" className="mt-auto">
-                <NextLink href="/indicators">View Indicators</NextLink>
+                <NextLink href="/tracker">View Tracker</NextLink>
               </Button>
             </Card.Root>
 

--- a/src/app/tracker/page.tsx
+++ b/src/app/tracker/page.tsx
@@ -1,0 +1,133 @@
+'use client'
+import { Container, Heading, Grid, Stack, Box } from '@chakra-ui/react'
+import { StrategySummaryCard } from '@/components/tracker/StrategySummaryCard'
+import { WeeklyBarChart } from '@/components/tracker/WeeklyBarChart'
+import { HabitLineChart } from '@/components/tracker/HabitLineChart'
+import { DoneHeatmap } from '@/components/tracker/DoneHeatmap'
+import { BurnUpChart } from '@/components/tracker/BurnUpChart'
+import { StreakGanttChart } from '@/components/tracker/StreakGanttChart'
+import { ComplianceRadarChart } from '@/components/tracker/ComplianceRadarChart'
+import type { Goal, Strategy, StrategyHistory, TrackerData } from './types'
+
+// Helper: compute done flags per strategy
+export function computeDoneFlags(data: TrackerData): Record<string, number[]> {
+  const result: Record<string, number[]> = {}
+  data.goals.forEach((g) => {
+    g.strategies.forEach((s) => {
+      result[s.id] = Array(12).fill(0)
+    })
+  })
+  data.history.forEach((h) => {
+    if (h.sequence >= 1 && h.sequence <= 12) {
+      if (!result[h.strategyId]) {
+        result[h.strategyId] = Array(12).fill(0)
+      }
+      result[h.strategyId][h.sequence - 1] = h.completed ? 1 : 0
+    }
+  })
+  return result
+}
+
+// Helper: compute metrics per strategy
+export function computeStrategyMetrics(done: Record<string, number[]>) {
+  const metrics: Record<string, { complianceRate: number; currentStreak: number; longestStreak: number }> = {}
+  Object.entries(done).forEach(([id, arr]) => {
+    const total = arr.reduce((a, b) => a + b, 0)
+    const complianceRate = (total / arr.length) * 100
+    let currentStreak = 0
+    for (let i = arr.length - 1; i >= 0; i--) {
+      if (arr[i]) currentStreak++
+      else break
+    }
+    let longestStreak = 0
+    let streak = 0
+    arr.forEach((v) => {
+      if (v) {
+        streak++
+        if (streak > longestStreak) longestStreak = streak
+      } else {
+        streak = 0
+      }
+    })
+    metrics[id] = { complianceRate, currentStreak, longestStreak }
+  })
+  return metrics
+}
+
+// Helper: compute week metrics
+export function computeWeekMetrics(done: Record<string, number[]>) {
+  const numStrategies = Object.keys(done).length
+  const weeklyWinCount = Array(12).fill(0)
+  Object.values(done).forEach((arr) => {
+    arr.forEach((v, idx) => {
+      weeklyWinCount[idx] += v
+    })
+  })
+  const habitPercent = weeklyWinCount.map((c) => (numStrategies ? (c / numStrategies) * 100 : 0))
+  return { weeklyWinCount, habitPercent }
+}
+
+interface TrackerPageProps {
+  data: TrackerData
+  title?: string
+}
+
+export default function TrackerPage({ data, title = 'Habit Tracker' }: TrackerPageProps) {
+  const done = computeDoneFlags(data)
+  const strategyMetrics = computeStrategyMetrics(done)
+  const weekMetrics = computeWeekMetrics(done)
+  const cumulative = weekMetrics.weeklyWinCount.reduce<number[]>((acc, v, idx) => {
+    acc[idx] = (acc[idx - 1] || 0) + v
+    return acc
+  }, [])
+  const strategies: Strategy[] = data.goals.flatMap((g) => g.strategies)
+
+  return (
+    <Container maxW="6xl" py={8}>
+      <Heading mb={4}>{title}</Heading>
+      <Grid templateColumns={{ base: '1fr', md: 'repeat(auto-fill, minmax(250px,1fr))' }} gap={4}>
+        {strategies.map((s) => (
+          <StrategySummaryCard key={s.id} strategy={s} metrics={strategyMetrics[s.id]} />
+        ))}
+      </Grid>
+      <Stack spacing={8} mt={8}>
+        <Box>
+          <Heading size="md" mb={2}>
+            Weekly Wins
+          </Heading>
+          <WeeklyBarChart data={weekMetrics.weeklyWinCount} />
+        </Box>
+        <Box>
+          <Heading size="md" mb={2}>
+            Habit Completion %
+          </Heading>
+          <HabitLineChart data={weekMetrics.habitPercent} />
+        </Box>
+        <Box>
+          <Heading size="md" mb={2}>
+            Completion Heatmap
+          </Heading>
+          <DoneHeatmap strategies={strategies} done={done} />
+        </Box>
+        <Box>
+          <Heading size="md" mb={2}>
+            Burn Up
+          </Heading>
+          <BurnUpChart data={cumulative} />
+        </Box>
+        <Box>
+          <Heading size="md" mb={2}>
+            Streaks
+          </Heading>
+          <StreakGanttChart strategies={strategies} done={done} />
+        </Box>
+        <Box>
+          <Heading size="md" mb={2}>
+            Compliance Radar
+          </Heading>
+          <ComplianceRadarChart strategies={strategies} metrics={strategyMetrics} />
+        </Box>
+      </Stack>
+    </Container>
+  )
+}

--- a/src/app/tracker/page.tsx
+++ b/src/app/tracker/page.tsx
@@ -27,13 +27,20 @@ export function computeDoneFlags(strategies: StrategyHistoryExtended[]): Record<
   //     result[h.strategyId][h.sequence - 1] = h.completed ? 1 : 0
   //   }
   // })
+  // strategies.forEach((s) => {
+  //   result[s.id] = Array(12).fill(0)
+  //   s.frequencies.forEach((f, idx) => {
+  //     if (f) {
+  //       result[s.id][idx] = 1
+  //     }
+  //   })
+  // })
+
   strategies.forEach((s) => {
-    result[s.id] = Array(12).fill(0)
-    s.frequencies.forEach((f, idx) => {
-      if (f) {
-        result[s.id][idx] = 1
-      }
-    })
+    if (!result[s.strategyId]) {
+      result[s.strategyId] = Array(12).fill(0)
+    }
+    result[s.strategyId][s.sequence - 1] = s.strategy.frequency === s.frequencies.filter(v => !!v).length ? 1 : 0;
   })
   console.log('result', result)
   return result
@@ -85,8 +92,12 @@ export default function TrackerPage() {
   // const { data: goals = [] } =
   //   goalActions.useGetByPlanId(plan?.id as string);
   
-    const { data: strategies = [] } =
-    strategyHistoryActions.useGetByPlanId(plan?.id as string);
+  const { data: strategies = [] } =
+  strategyHistoryActions.useGetByPlanId(plan?.id as string);
+
+  const uniqueStrategies = strategies.filter((s, idx, arr) => {
+    return arr.findIndex((t) => t.strategyId === s.strategyId) === idx
+  })
 
   const done = computeDoneFlags(strategies)
   const strategyMetrics = computeStrategyMetrics(done)
@@ -100,8 +111,8 @@ export default function TrackerPage() {
     <Container maxW="6xl" py={8}>
       <Heading mb={4}>{title}</Heading>
       <Grid templateColumns={{ base: '1fr', md: 'repeat(auto-fill, minmax(250px,1fr))' }} gap={4}>
-        {strategies.map((s) => (
-          <StrategySummaryCard key={s.id} strategy={s} metrics={strategyMetrics[s.id]} />
+        {uniqueStrategies.map((s) => (
+          <StrategySummaryCard key={s.strategyId} strategy={s} metrics={strategyMetrics[s.strategyId]} />
         ))}
       </Grid>
       <Stack gap={8} mt={8}>
@@ -121,26 +132,26 @@ export default function TrackerPage() {
           <Heading size="md" mb={2}>
             Completion Heatmap
           </Heading>
-          <DoneHeatmap strategies={strategies} done={done} />
+          <DoneHeatmap strategies={uniqueStrategies} done={done} />
         </Box>
-        <Box>
+        {/* <Box>
           <Heading size="md" mb={2}>
             Burn Up
           </Heading>
           <BurnUpChart data={cumulative} />
-        </Box>
+        </Box> */}
         <Box>
           <Heading size="md" mb={2}>
             Streaks
           </Heading>
-          <StreakGanttChart strategies={strategies} done={done} />
+          <StreakGanttChart strategies={uniqueStrategies} done={done} />
         </Box>
-        <Box>
+        {/* <Box>
           <Heading size="md" mb={2}>
             Compliance Radar
           </Heading>
-          <ComplianceRadarChart strategies={strategies} metrics={strategyMetrics} />
-        </Box>
+          <ComplianceRadarChart strategies={uniqueStrategies} metrics={strategyMetrics} />
+        </Box> */}
       </Stack>
     </Container>
   )

--- a/src/app/tracker/types.ts
+++ b/src/app/tracker/types.ts
@@ -1,0 +1,23 @@
+export type Goal = {
+  id: string
+  content: string
+  strategies: Strategy[]
+}
+
+export type Strategy = {
+  id: string
+  content: string
+  frequency: number
+  goalId: string
+}
+
+export type StrategyHistory = {
+  strategyId: string
+  sequence: number
+  completed: boolean
+}
+
+export interface TrackerData {
+  goals: Goal[]
+  history: StrategyHistory[]
+}

--- a/src/app/util/supabase/middleware.ts
+++ b/src/app/util/supabase/middleware.ts
@@ -50,6 +50,7 @@ export async function updateSession(request: NextRequest) {
   const isDashboard = pathname.startsWith('/dashboard')
   const isPlanNew = pathname === '/plan/new'
   const isPlan = pathname === '/plan'
+  const isTracker = pathname.startsWith('/tracker')
 
   // 3) If no user → only allow auth pages
   if (!user && !isAuthPage && !userError) {
@@ -84,7 +85,7 @@ export async function updateSession(request: NextRequest) {
       }
     }
 
-    if (plan && plan.started && !isDashboard) {
+    if (plan && plan.started && !(isDashboard || isPlan || isTracker)) {
       return NextResponse.redirect(new URL('/dashboard', request.url))
     }
   }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 import { Flex, HStack, Heading, IconButton, Separator, Text, Link as ChakraLink } from '@chakra-ui/react'
 import { SlLogin, SlLogout, SlNotebook } from 'react-icons/sl'
 import { LuUserPlus } from 'react-icons/lu'
+import { AiOutlineBarChart } from 'react-icons/ai'
 // import { RiHome2Line } from 'react-icons/ri'
 import { RxDashboard } from 'react-icons/rx'
 // import { PiFileText } from 'react-icons/pi'
@@ -12,9 +13,11 @@ import { SyncService } from '@/services/sync'
 import { useAuth } from '@/app/providers/AuthProvider'
 import { logout } from '@/services/auth'
 import { clearStrategyOrder } from '@/app/util/order'
+import { usePlanContext } from '@/app/providers/usePlanContext'
 
 export function Header() {
   const { session, user } = useAuth()
+  const { hasStartedPlan } = usePlanContext()
   const router = useRouter()
   const pathname = usePathname()
   const userAvatar = user?.user_metadata?.picture || `https://ui-avatars.com/api/?background=000&color=fff&rounded=true&name=${user?.email?.split('@')[0] || user?.user_metadata?.name || 'Guest%20User'}`
@@ -82,6 +85,20 @@ export function Header() {
             <SlNotebook />
             <Text display={{ base: 'none', md: 'inline' }}>Plan</Text>
           </ChakraLink>
+          {hasStartedPlan && (
+            <ChakraLink
+              as={Link}
+              href="/tracker"
+
+              display="flex"
+              alignItems="center"
+              gap="1"
+              fontWeight={pathname.startsWith('/tracker') ? 'bold' : 'normal'}
+            >
+              <AiOutlineBarChart />
+              <Text display={{ base: 'none', md: 'inline' }}>Tracker</Text>
+            </ChakraLink>
+          )}
           {/* <ChakraLink
             as={Link}
             href="/templates"

--- a/src/components/tracker/BurnUpChart.tsx
+++ b/src/components/tracker/BurnUpChart.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
+
+interface BurnUpChartProps {
+  data: number[]
+}
+
+export function BurnUpChart({ data }: BurnUpChartProps) {
+  const chartData = data.map((val, idx) => ({ week: idx + 1, value: val }))
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={chartData}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="week" />
+        <YAxis allowDecimals={false} />
+        <Tooltip />
+        <Line type="monotone" dataKey="value" stroke="#D53F8C" />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/components/tracker/ComplianceRadarChart.tsx
+++ b/src/components/tracker/ComplianceRadarChart.tsx
@@ -1,0 +1,23 @@
+'use client'
+import { ResponsiveContainer, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, Tooltip } from 'recharts'
+import type { Strategy } from '@/app/tracker/types'
+
+interface ComplianceRadarChartProps {
+  strategies: Strategy[]
+  metrics: Record<string, { complianceRate: number }>
+}
+
+export function ComplianceRadarChart({ strategies, metrics }: ComplianceRadarChartProps) {
+  const data = strategies.map((s) => ({ name: s.content, value: metrics[s.id]?.complianceRate || 0 }))
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <RadarChart data={data}>
+        <PolarGrid />
+        <PolarAngleAxis dataKey="name" />
+        <PolarRadiusAxis angle={30} domain={[0, 100]} tickFormatter={(t) => `${t}%`} />
+        <Tooltip formatter={(v: number) => `${v}%`} />
+        <Radar dataKey="value" stroke="#805AD5" fill="#805AD5" fillOpacity={0.6} />
+      </RadarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/components/tracker/ComplianceRadarChart.tsx
+++ b/src/components/tracker/ComplianceRadarChart.tsx
@@ -1,14 +1,14 @@
 'use client'
 import { ResponsiveContainer, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, Tooltip } from 'recharts'
-import type { Strategy } from '@/app/tracker/types'
+import { StrategyHistoryExtended } from '@/app/types/types'
 
 interface ComplianceRadarChartProps {
-  strategies: Strategy[]
+  strategies: StrategyHistoryExtended[]
   metrics: Record<string, { complianceRate: number }>
 }
 
 export function ComplianceRadarChart({ strategies, metrics }: ComplianceRadarChartProps) {
-  const data = strategies.map((s) => ({ name: s.content, value: metrics[s.id]?.complianceRate || 0 }))
+  const data = strategies.map((s) => ({ name: s.strategy.content, value: metrics[s.id]?.complianceRate || 0 }))
   return (
     <ResponsiveContainer width="100%" height={300}>
       <RadarChart data={data}>

--- a/src/components/tracker/ComplianceRadarChart.tsx
+++ b/src/components/tracker/ComplianceRadarChart.tsx
@@ -8,7 +8,7 @@ interface ComplianceRadarChartProps {
 }
 
 export function ComplianceRadarChart({ strategies, metrics }: ComplianceRadarChartProps) {
-  const data = strategies.map((s) => ({ name: s.strategy.content, value: metrics[s.id]?.complianceRate || 0 }))
+  const data = strategies.map((s) => ({ name: s.strategy.content, value: metrics[s.strategyId]?.complianceRate || 0 }))
   return (
     <ResponsiveContainer width="100%" height={300}>
       <RadarChart data={data}>

--- a/src/components/tracker/DoneHeatmap.tsx
+++ b/src/components/tracker/DoneHeatmap.tsx
@@ -1,9 +1,9 @@
 'use client'
 import { Box, Grid, GridItem, Text } from '@chakra-ui/react'
-import type { Strategy } from '@/app/tracker/types'
+import { StrategyHistoryExtended } from '@/app/types/types'
 
 interface DoneHeatmapProps {
-  strategies: Strategy[]
+  strategies: StrategyHistoryExtended[]
   done: Record<string, number[]>
 }
 
@@ -19,7 +19,7 @@ export function DoneHeatmap({ strategies, done }: DoneHeatmapProps) {
       {strategies.map((s) => (
         <>
           <GridItem key={s.id + '-label'} textAlign="right" pr={1}>
-            <Text noOfLines={1}>{s.content}</Text>
+            <Text>{s.strategy.content}</Text>
           </GridItem>
           {done[s.id].map((v, idx) => (
             <GridItem key={s.id + idx}>

--- a/src/components/tracker/DoneHeatmap.tsx
+++ b/src/components/tracker/DoneHeatmap.tsx
@@ -18,11 +18,11 @@ export function DoneHeatmap({ strategies, done }: DoneHeatmapProps) {
       ))}
       {strategies.map((s) => (
         <>
-          <GridItem key={s.id + '-label'} textAlign="right" pr={1}>
+          <GridItem key={s.strategyId + '-label'} textAlign="right" pr={1}>
             <Text>{s.strategy.content}</Text>
           </GridItem>
-          {done[s.id].map((v, idx) => (
-            <GridItem key={s.id + idx}>
+          {done[s.strategyId].map((v, idx) => (
+            <GridItem key={s.strategyId + idx}>
               <Box h={4} borderRadius="sm" bg={v ? 'green.400' : 'gray.200'} />
             </GridItem>
           ))}

--- a/src/components/tracker/DoneHeatmap.tsx
+++ b/src/components/tracker/DoneHeatmap.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { Box, Grid, GridItem, Text } from '@chakra-ui/react'
+import type { Strategy } from '@/app/tracker/types'
+
+interface DoneHeatmapProps {
+  strategies: Strategy[]
+  done: Record<string, number[]>
+}
+
+export function DoneHeatmap({ strategies, done }: DoneHeatmapProps) {
+  return (
+    <Grid templateColumns={`repeat(${13}, 1fr)`} gap={1} fontSize="xs">
+      <GridItem></GridItem>
+      {Array.from({ length: 12 }).map((_, idx) => (
+        <GridItem key={idx} textAlign="center">
+          {idx + 1}
+        </GridItem>
+      ))}
+      {strategies.map((s) => (
+        <>
+          <GridItem key={s.id + '-label'} textAlign="right" pr={1}>
+            <Text noOfLines={1}>{s.content}</Text>
+          </GridItem>
+          {done[s.id].map((v, idx) => (
+            <GridItem key={s.id + idx}>
+              <Box h={4} borderRadius="sm" bg={v ? 'green.400' : 'gray.200'} />
+            </GridItem>
+          ))}
+        </>
+      ))}
+    </Grid>
+  )
+}

--- a/src/components/tracker/HabitLineChart.tsx
+++ b/src/components/tracker/HabitLineChart.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
+
+interface HabitLineChartProps {
+  data: number[]
+}
+
+export function HabitLineChart({ data }: HabitLineChartProps) {
+  const chartData = data.map((percent, idx) => ({ week: idx + 1, percent }))
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={chartData}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="week" />
+        <YAxis domain={[0, 100]} tickFormatter={(t) => `${t}%`} />
+        <Tooltip formatter={(v: number) => `${v}%`} />
+        <Line type="monotone" dataKey="percent" stroke="#38A169" />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/components/tracker/StrategySummaryCard.tsx
+++ b/src/components/tracker/StrategySummaryCard.tsx
@@ -1,9 +1,9 @@
 'use client'
 import { Box, Heading, Text, Stack } from '@chakra-ui/react'
-import type { Strategy } from '@/app/tracker/types'
+import { StrategyHistoryExtended } from '@/app/types/types'
 
 interface StrategySummaryCardProps {
-  strategy: Strategy
+  strategy: StrategyHistoryExtended
   metrics: {
     complianceRate: number
     currentStreak: number
@@ -14,8 +14,8 @@ interface StrategySummaryCardProps {
 export function StrategySummaryCard({ strategy, metrics }: StrategySummaryCardProps) {
   return (
     <Box borderWidth="1px" borderRadius="md" p={4}>
-      <Stack spacing={1}>
-        <Heading size="sm">{strategy.content}</Heading>
+      <Stack gap={1}>
+        <Heading size="sm">{strategy.strategy.content}</Heading>
         <Text>Compliance: {metrics.complianceRate.toFixed(0)}%</Text>
         <Text>Current Streak: {metrics.currentStreak}</Text>
         <Text>Longest Streak: {metrics.longestStreak}</Text>

--- a/src/components/tracker/StrategySummaryCard.tsx
+++ b/src/components/tracker/StrategySummaryCard.tsx
@@ -1,0 +1,25 @@
+'use client'
+import { Box, Heading, Text, Stack } from '@chakra-ui/react'
+import type { Strategy } from '@/app/tracker/types'
+
+interface StrategySummaryCardProps {
+  strategy: Strategy
+  metrics: {
+    complianceRate: number
+    currentStreak: number
+    longestStreak: number
+  }
+}
+
+export function StrategySummaryCard({ strategy, metrics }: StrategySummaryCardProps) {
+  return (
+    <Box borderWidth="1px" borderRadius="md" p={4}>
+      <Stack spacing={1}>
+        <Heading size="sm">{strategy.content}</Heading>
+        <Text>Compliance: {metrics.complianceRate.toFixed(0)}%</Text>
+        <Text>Current Streak: {metrics.currentStreak}</Text>
+        <Text>Longest Streak: {metrics.longestStreak}</Text>
+      </Stack>
+    </Box>
+  )
+}

--- a/src/components/tracker/StreakGanttChart.tsx
+++ b/src/components/tracker/StreakGanttChart.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { Box, Stack, Grid } from '@chakra-ui/react'
+import type { Strategy } from '@/app/tracker/types'
+
+interface StreakGanttChartProps {
+  strategies: Strategy[]
+  done: Record<string, number[]>
+}
+
+export function StreakGanttChart({ strategies, done }: StreakGanttChartProps) {
+  return (
+    <Stack spacing={1} fontSize="xs">
+      {strategies.map((s) => (
+        <Grid key={s.id} templateColumns={`repeat(12, 1fr)`} gap={1}>
+          {done[s.id].map((v, idx) => (
+            <Box key={idx} h={3} bg={v ? 'green.500' : 'gray.200'} borderRadius="sm" />
+          ))}
+        </Grid>
+      ))}
+    </Stack>
+  )
+}

--- a/src/components/tracker/StreakGanttChart.tsx
+++ b/src/components/tracker/StreakGanttChart.tsx
@@ -1,15 +1,15 @@
 'use client'
 import { Box, Stack, Grid } from '@chakra-ui/react'
-import type { Strategy } from '@/app/tracker/types'
+import { StrategyHistoryExtended } from '@/app/types/types'
 
 interface StreakGanttChartProps {
-  strategies: Strategy[]
+  strategies: StrategyHistoryExtended[]
   done: Record<string, number[]>
 }
 
 export function StreakGanttChart({ strategies, done }: StreakGanttChartProps) {
   return (
-    <Stack spacing={1} fontSize="xs">
+    <Stack gap={1} fontSize="xs">
       {strategies.map((s) => (
         <Grid key={s.id} templateColumns={`repeat(12, 1fr)`} gap={1}>
           {done[s.id].map((v, idx) => (

--- a/src/components/tracker/StreakGanttChart.tsx
+++ b/src/components/tracker/StreakGanttChart.tsx
@@ -11,8 +11,8 @@ export function StreakGanttChart({ strategies, done }: StreakGanttChartProps) {
   return (
     <Stack gap={1} fontSize="xs">
       {strategies.map((s) => (
-        <Grid key={s.id} templateColumns={`repeat(12, 1fr)`} gap={1}>
-          {done[s.id].map((v, idx) => (
+        <Grid key={s.strategyId} templateColumns={`repeat(12, 1fr)`} gap={1}>
+          {done[s.strategyId].map((v, idx) => (
             <Box key={idx} h={3} bg={v ? 'green.500' : 'gray.200'} borderRadius="sm" />
           ))}
         </Grid>

--- a/src/components/tracker/WeeklyBarChart.tsx
+++ b/src/components/tracker/WeeklyBarChart.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
+
+interface WeeklyBarChartProps {
+  data: number[]
+}
+
+export function WeeklyBarChart({ data }: WeeklyBarChartProps) {
+  const chartData = data.map((count, idx) => ({ week: idx + 1, count }))
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={chartData}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="week" />
+        <YAxis allowDecimals={false} />
+        <Tooltip />
+        <Bar dataKey="count" fill="#3182CE" />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}


### PR DESCRIPTION
## Summary
- add tracker page with helper functions and dashboard layout
- implement tracker chart components: bar, line, heatmap, burn-up, streak gantt, radar
- add shared tracker types

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68829714b5a08332877f96d3884a0890