### PR TITLE
Add tracker metrics charts

### DIFF
--- a/src/app/api/tracker/metrics/get.ts
+++ b/src/app/api/tracker/metrics/get.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from 'next/server'
+import { strategyHistoryHandler } from '@/db/prismaHandler'
+
+export async function GET(request: NextRequest) {
+  const planId = request.nextUrl.searchParams.get('planId')
+  if (!planId) {
+    return new Response('Invalid plan id', { status: 400 })
+  }
+
+  try {
+    const histories = await strategyHistoryHandler.findMany({ planId })
+    const strategyData: Record<string, number[]> = {}
+    const goalAccum: Record<string, { totals: number[]; counts: number[] }> = {}
+
+    histories.forEach((h) => {
+      const seqIndex = h.sequence - 1
+      const freq = h.strategy.frequency || 0
+      const completed = h.frequencies.filter(Boolean).length
+      const percent = freq ? Math.min(100, (completed / freq) * 100) : 100
+
+      if (!strategyData[h.strategyId]) {
+        strategyData[h.strategyId] = Array(12).fill(0)
+      }
+      strategyData[h.strategyId][seqIndex] = percent
+
+      const goalId = h.strategy.goalId
+      if (!goalAccum[goalId]) {
+        goalAccum[goalId] = { totals: Array(12).fill(0), counts: Array(12).fill(0) }
+      }
+      goalAccum[goalId].totals[seqIndex] += percent
+      goalAccum[goalId].counts[seqIndex] += 1
+    })
+
+    const goalData: Record<string, number[]> = {}
+    Object.entries(goalAccum).forEach(([goalId, val]) => {
+      goalData[goalId] = val.totals.map((t, idx) => (val.counts[idx] ? t / val.counts[idx] : 0))
+    })
+
+    return new Response(JSON.stringify({ strategies: strategyData, goals: goalData }), {
+      status: 200,
+    })
+  } catch (error) {
+    return new Response(JSON.stringify({ error, ok: false }), { status: 500 })
+  }
+}

--- a/src/app/api/tracker/metrics/route.ts
+++ b/src/app/api/tracker/metrics/route.ts
@@ -1,0 +1,1 @@
+export * from './get'

--- a/src/app/hooks/useTrackerMetrics.ts
+++ b/src/app/hooks/useTrackerMetrics.ts
@@ -1,0 +1,14 @@
+import { TrackerService, TrackerMetrics } from '@/services/tracker'
+import { useQuery } from '@tanstack/react-query'
+
+const QUERY_KEY = 'tracker-metrics'
+
+export function useTrackerMetrics(planId: string) {
+  return useQuery<TrackerMetrics>({
+    queryKey: [QUERY_KEY, { planId }],
+    queryFn: () => TrackerService.getMetrics(planId),
+    enabled: !!planId,
+  })
+}
+
+export type UseTrackerMetrics = ReturnType<typeof useTrackerMetrics>

--- a/src/app/tracker/page.tsx
+++ b/src/app/tracker/page.tsx
@@ -7,9 +7,11 @@ import { DoneHeatmap } from '@/components/tracker/DoneHeatmap'
 import { BurnUpChart } from '@/components/tracker/BurnUpChart'
 import { StreakGanttChart } from '@/components/tracker/StreakGanttChart'
 import { ComplianceRadarChart } from '@/components/tracker/ComplianceRadarChart'
+import { GoalCompletionLineChart } from '@/components/tracker/GoalCompletionLineChart'
 import type { Goal, Strategy, StrategyHistory, TrackerData } from './types'
 import { usePlanContext } from '@/app/providers/usePlanContext'
 import { StrategyHistoryExtended } from '@/app/types/types'
+import { useTrackerMetrics } from '@/app/hooks/useTrackerMetrics'
 
 // Helper: compute done flags per strategy
 export function computeDoneFlags(strategies: StrategyHistoryExtended[]): Record<string, number[]> {
@@ -88,9 +90,9 @@ export function computeWeekMetrics(done: Record<string, number[]>) {
 export default function TrackerPage() {
   const title = 'Tracker'
   const { plan, goalActions, strategyHistoryActions } = usePlanContext();
-  
-  // const { data: goals = [] } =
-  //   goalActions.useGetByPlanId(plan?.id as string);
+
+  const { data: goals = [] } = goalActions.useGetByPlanId(plan?.id as string);
+  const { data: metrics } = useTrackerMetrics(plan?.id as string);
   
   const { data: strategies = [] } =
   strategyHistoryActions.useGetByPlanId(plan?.id as string);
@@ -112,7 +114,12 @@ export default function TrackerPage() {
       <Heading mb={4}>{title}</Heading>
       <Grid templateColumns={{ base: '1fr', md: 'repeat(auto-fill, minmax(250px,1fr))' }} gap={4}>
         {uniqueStrategies.map((s) => (
-          <StrategySummaryCard key={s.strategyId} strategy={s} metrics={strategyMetrics[s.strategyId]} />
+          <StrategySummaryCard
+            key={s.strategyId}
+            strategy={s}
+            metrics={strategyMetrics[s.strategyId]}
+            weeklyData={metrics?.strategies[s.strategyId]}
+          />
         ))}
       </Grid>
       <Stack gap={8} mt={8}>
@@ -127,6 +134,12 @@ export default function TrackerPage() {
             Habit Completion %
           </Heading>
           <HabitLineChart data={weekMetrics.habitPercent} />
+        </Box>
+        <Box>
+          <Heading size="md" mb={2}>
+            Goal Completion %
+          </Heading>
+          <GoalCompletionLineChart data={metrics?.goals || {}} goals={goals} />
         </Box>
         <Box>
           <Heading size="md" mb={2}>

--- a/src/components/tracker/GoalCompletionLineChart.tsx
+++ b/src/components/tracker/GoalCompletionLineChart.tsx
@@ -1,0 +1,34 @@
+'use client'
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts'
+
+interface GoalCompletionLineChartProps {
+  data: Record<string, number[]>
+  goals: { id: string; content: string }[]
+}
+
+export function GoalCompletionLineChart({ data, goals }: GoalCompletionLineChartProps) {
+  const chartData = Array.from({ length: 12 }).map((_, idx) => {
+    const entry: Record<string, number> & { week: number } = { week: idx + 1 }
+    goals.forEach(g => {
+      entry[g.id] = data[g.id]?.[idx] ?? 0
+    })
+    return entry
+  })
+
+  const colors = ['#3182CE', '#38A169', '#D53F8C', '#805AD5', '#DD6B20', '#2C5282', '#718096']
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={chartData}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="week" />
+        <YAxis domain={[0, 100]} tickFormatter={(t) => `${t}%`} />
+        <Tooltip formatter={(v: number) => `${v}%`} />
+        <Legend />
+        {goals.map((g, idx) => (
+          <Line key={g.id} type="monotone" dataKey={g.id} name={g.content} stroke={colors[idx % colors.length]} />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/components/tracker/HabitLineChart.tsx
+++ b/src/components/tracker/HabitLineChart.tsx
@@ -3,12 +3,13 @@ import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tool
 
 interface HabitLineChartProps {
   data: number[]
+  height?: number
 }
 
-export function HabitLineChart({ data }: HabitLineChartProps) {
+export function HabitLineChart({ data, height = 300 }: HabitLineChartProps) {
   const chartData = data.map((percent, idx) => ({ week: idx + 1, percent }))
   return (
-    <ResponsiveContainer width="100%" height={300}>
+    <ResponsiveContainer width="100%" height={height}>
       <LineChart data={chartData}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="week" />

--- a/src/components/tracker/StrategySummaryCard.tsx
+++ b/src/components/tracker/StrategySummaryCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { Box, Heading, Text, Stack } from '@chakra-ui/react'
 import { StrategyHistoryExtended } from '@/app/types/types'
+import { HabitLineChart } from './HabitLineChart'
 
 interface StrategySummaryCardProps {
   strategy: StrategyHistoryExtended
@@ -9,9 +10,10 @@ interface StrategySummaryCardProps {
     currentStreak: number
     longestStreak: number
   }
+  weeklyData?: number[]
 }
 
-export function StrategySummaryCard({ strategy, metrics }: StrategySummaryCardProps) {
+export function StrategySummaryCard({ strategy, metrics, weeklyData }: StrategySummaryCardProps) {
   return (
     <Box borderWidth="1px" borderRadius="md" p={4}>
       <Stack gap={1}>
@@ -19,6 +21,7 @@ export function StrategySummaryCard({ strategy, metrics }: StrategySummaryCardPr
         <Text>Compliance: {metrics.complianceRate.toFixed(0)}%</Text>
         <Text>Current Streak: {metrics.currentStreak}</Text>
         <Text>Longest Streak: {metrics.longestStreak}</Text>
+        {weeklyData && <HabitLineChart data={weeklyData} height={150} />}
       </Stack>
     </Box>
   )

--- a/src/services/tracker.ts
+++ b/src/services/tracker.ts
@@ -1,0 +1,14 @@
+export interface TrackerMetrics {
+  strategies: Record<string, number[]>
+  goals: Record<string, number[]>
+}
+
+const getMetrics = async (planId: string): Promise<TrackerMetrics> => {
+  const response = await fetch(`/api/tracker/metrics?planId=${planId}`)
+  if (!response.ok) {
+    return { strategies: {}, goals: {} }
+  }
+  return response.json()
+}
+
+export const TrackerService = { getMetrics }


### PR DESCRIPTION
## Summary
- compute metrics server-side via new `/api/tracker/metrics` endpoint
- expose hook to fetch tracker metrics
- display weekly completion charts for each action and overall goal averages
- add GoalCompletionLineChart component and extend existing charts

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882a75ce4908332931474c159bf5d6b