### PR TITLE
Add landing page counters and pricing

### DIFF
--- a/src/app/api/stats/get.ts
+++ b/src/app/api/stats/get.ts
@@ -1,0 +1,15 @@
+import { waitlistHandler, userHandler } from '@/db/prismaHandler'
+import { NextRequest } from 'next/server'
+
+export async function GET(_: NextRequest) {
+  try {
+    const waitlist = await waitlistHandler.findMany()
+    const users = await userHandler.findMany()
+    return new Response(
+      JSON.stringify({ waitlist: waitlist.length, users: users.length }),
+      { status: 200 },
+    )
+  } catch (error) {
+    return new Response(JSON.stringify({ error, ok: false }), { status: 500 })
+  }
+}

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,0 +1,1 @@
+export * from './get'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,31 +1,61 @@
 'use client'
-import { Button, Flex, Heading, Text } from '@chakra-ui/react'
-import { useRouter } from 'next/navigation'
-import { RiArrowRightLine } from 'react-icons/ri'
+import { Box, Button, Flex, Heading, Stack, Text } from '@chakra-ui/react'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { AnimatedCounter } from '@/components/AnimatedCounter'
 
 export default function Home() {
-  const router = useRouter()
+  const [stats, setStats] = useState({ waitlist: 0, users: 0 })
+
+  useEffect(() => {
+    fetch('/api/stats')
+      .then((res) => res.json())
+      .then((data) => setStats(data))
+      .catch(() => {})
+  }, [])
 
   return (
-    <div className="container">
-      <section className="page" id="get-started">
-        <Heading as="h1" size={{ lg: "7xl", base: "4xl" }}>The Planner</Heading>
-        <Flex flexDir="column" gap="1rem" alignItems="center">
-          <Text>Stay Focused and Achieve More</Text>
-          <Button size="xl" onClick={() => router.push('/signup')} colorPalette="yellow" variant="subtle" width="100%">Get Started <RiArrowRightLine /></Button>
-          <Text fontSize="xs">Already have an account?</Text>
-        </Flex>
-        <Button size="xs" onClick={() => router.push('/login')} variant="plain" textDecoration="underline">Login</Button>
-      </section>
-      {/* <section className="page" id="description">
-        <Heading size="5xl">Create Your Plan</Heading>
-      </section> */}
-      {/* <section className="page" id="pricing">
-        Pricing... TBD
-      </section> */}
-      {/* <section className="page" id="wait-list">
-        <WaitListSection />
-      </section> */}
-    </div>
+    <Stack spacing={20} py={10}>
+      <Box textAlign="center">
+        <Heading size={{ lg: '7xl', base: '4xl' }} mb={4}>
+          The Planner
+        </Heading>
+        <Text fontSize="xl" mb={6}>
+          Stay focused and achieve more with a simple 12‑week planning tool.
+        </Text>
+        <Button
+          as={Link}
+          href="/signup"
+          colorPalette="yellow"
+          variant="subtle"
+          size="xl"
+        >
+          Get Started
+        </Button>
+      </Box>
+      <Flex justify="center" gap={10}>
+        <AnimatedCounter label="On the Waitlist" value={stats.waitlist} />
+        <AnimatedCounter label="Active Users" value={stats.users} />
+      </Flex>
+      <Box textAlign="center">
+        <Heading size="xl" mb={4}>
+          Why The Planner?
+        </Heading>
+        <Stack spacing={2}>
+          <Text>Simplicity over cluttered tools.</Text>
+          <Text>Keep your goals organized.</Text>
+          <Text>Track progress every week.</Text>
+        </Stack>
+      </Box>
+      <Box textAlign="center">
+        <Heading size="xl" mb={4}>
+          Pricing
+        </Heading>
+        <Text mb={4}>Free or just $1 a month (or $10 a year).</Text>
+        <Button as={Link} href="/pricing" variant="outline" size="lg">
+          Learn More
+        </Button>
+      </Box>
+    </Stack>
   )
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { Box, Heading, Stack, Text } from '@chakra-ui/react'
+
+export default function PricingPage() {
+  return (
+    <Box textAlign="center" py={10}>
+      <Heading size="2xl" mb={6}>Pricing</Heading>
+      <Stack spacing={8} maxW="600px" mx="auto">
+        <Box>
+          <Heading size="lg">Free</Heading>
+          <Text>Plan your goals with our basic tools.</Text>
+        </Box>
+        <Box>
+          <Heading size="lg">$1 per Month</Heading>
+          <Text>Unlock cloud sync and priority support.</Text>
+        </Box>
+        <Box>
+          <Heading size="lg">$10 per Year</Heading>
+          <Text>Get two months free when paying yearly.</Text>
+        </Box>
+      </Stack>
+    </Box>
+  )
+}

--- a/src/components/AnimatedCounter.tsx
+++ b/src/components/AnimatedCounter.tsx
@@ -1,0 +1,34 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { StatRoot, StatLabel, StatValueText } from '@/components/ui/stat'
+
+interface AnimatedCounterProps {
+  label: string
+  value: number
+}
+
+export function AnimatedCounter({ label, value }: AnimatedCounterProps) {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    let current = 0
+    const duration = 1000
+    const step = Math.max(1, Math.ceil(value / (duration / 50)))
+    const interval = setInterval(() => {
+      current += step
+      if (current >= value) {
+        current = value
+        clearInterval(interval)
+      }
+      setCount(current)
+    }, 50)
+    return () => clearInterval(interval)
+  }, [value])
+
+  return (
+    <StatRoot textAlign="center">
+      <StatLabel>{label}</StatLabel>
+      <StatValueText>{count}</StatValueText>
+    </StatRoot>
+  )
+}


### PR DESCRIPTION
## Summary
- create AnimatedCounter component
- show new landing page with stats, benefits and pricing link
- add pricing route
- expose `/api/stats` for user & waitlist counts

## Testing
- `npm run lint` *(fails: `'next' not found due to missing dependencies`)*

------
https://chatgpt.com/codex/tasks/task_e_6883cb12046483329761b8e0414cd09c