### PR TITLE
Fix default query logic

### DIFF
--- a/src/app/dashboard-legacy/dashboardContext.tsx
+++ b/src/app/dashboard-legacy/dashboardContext.tsx
@@ -41,17 +41,17 @@ export const DashboardProvider = ({ children, fetchHistory = true }: DashboardTr
   const strategyHistoryActions = useStrategyHistoryActions()
   const indicatorHistoryActions = useIndicatorHistoryActions()
 
-  const goals = fetchHistory
-    ? goalHistoryActions.useGetByPlanId(plan?.id as string)
-    : ({ data: [], isLoading: false, isRefetching: false } as ReturnType<typeof goalHistoryActions.useGetByPlanId>)
+  const goals = goalHistoryActions.useGetByPlanId(
+    fetchHistory ? (plan?.id ?? '') : ''
+  )
 
-  const strategies = fetchHistory
-    ? strategyHistoryActions.useGetByPlanId(plan?.id as string)
-    : ({ data: [], isLoading: false, isRefetching: false } as ReturnType<typeof strategyHistoryActions.useGetByPlanId>)
+  const strategies = strategyHistoryActions.useGetByPlanId(
+    fetchHistory ? (plan?.id ?? '') : ''
+  )
 
-  const indicators = fetchHistory
-    ? indicatorHistoryActions.useGetByPlanId(plan?.id as string)
-    : ({ data: [], isLoading: false, isRefetching: false } as ReturnType<typeof indicatorHistoryActions.useGetByPlanId>)
+  const indicators = indicatorHistoryActions.useGetByPlanId(
+    fetchHistory ? (plan?.id ?? '') : ''
+  )
 
   const isLoading = fetchHistory && (goals.isLoading || strategies.isLoading || indicators.isLoading)
   const isRefetching = fetchHistory && (goals.isRefetching || strategies.isRefetching || indicators.isRefetching)


### PR DESCRIPTION
## Summary
- always call query hooks in dashboard provider and disable fetch with empty ID

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Module '@prisma/client' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883fe0ad4dc833287349da1ac6fcf65