### PR TITLE
Improve SEO meta tags

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,8 +29,17 @@ const geistMono = Geist_Mono({
 })
 
 export const metadata: Metadata = {
-  title: 'The Planner',
-  description: 'Achieve your goals faster with the 12-Week Year Plan Tracker. Create focused action plans, track progress weekly, and boost productivity—all in one place.',
+  title: 'The Planner - Plan Your Next Quarter',
+  description:
+    'The Planner helps you map out quarterly goals, track progress, and stay focused for the next 12 weeks.',
+  keywords: [
+    '12-week-year planner',
+    'plan',
+    'planner',
+    'quarter planner',
+    '3 months planner',
+    'simple planner',
+  ],
 }
 
 export default async function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,11 +11,12 @@ export default function Home() {
     <div className="container">
       <section className="page" id="get-started">
         <Heading as="h1" size={{ lg: "7xl", base: "4xl" }} display="flex" alignItems="center" gap="2" flexDirection={{ base: "column" }}>
-          <Image src="/logo-icon-no-bg.png" alt="The Planner" width="100" height="100" />
+          <Image src="/logo-icon-no-bg.png" alt="The Planner logo" width="100" height="100" />
           The Planner
         </Heading>
         <Flex flexDir="column" gap="1rem" alignItems="center">
           <Text>Stay Focused and Achieve More</Text>
+          <Text textAlign="center">A simple planner for your next quarter.</Text>
           <Button size="xl" onClick={() => router.push('/join')} colorPalette="cyan" variant="subtle" width="100%">Get Started <RiArrowRightLine /></Button>
           <Text fontSize="xs">Already have an account?</Text>
         </Flex>


### PR DESCRIPTION
## Summary
- expand metadata with SEO keywords
- tweak homepage heading and alt text
- soften mentions of "12-week" wording

## Testing
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_6884f970156083328c5242ee0ab5ce30