### PR TITLE
Fix plan creation duplicate bug

### DIFF
--- a/src/app/api/plan/post.ts
+++ b/src/app/api/plan/post.ts
@@ -12,7 +12,9 @@ export async function POST(request: NextRequest) {
 
   try {
     const parsedData = PlanSchema.parse(data)
-    const planInProgress = await planHandler.findStarted(data.users.connect.id)
+    const planInProgress = await planHandler.findInProgress(
+      data.users.connect.id
+    )
 
     if (!!planInProgress) {
       return new Response(JSON.stringify({ message: 'The user already has a plan in progress', ok: false }), { status: 400 })

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,7 +18,7 @@ import Image from 'next/image'
 
 export function Header() {
   const { session, user } = useAuth()
-  const { hasStartedPlan, hasPlan } = usePlanContext()
+  const { hasPlan } = usePlanContext()
   const router = useRouter()
   const pathname = usePathname()
   const userAvatar = user?.user_metadata?.picture || `https://ui-avatars.com/api/?background=000&color=fff&rounded=true&name=${user?.email?.split('@')[0] || user?.user_metadata?.name || 'Guest%20User'}`


### PR DESCRIPTION
## Summary
- ensure the POST `/api/plan` route checks for any unfinished plan using `findInProgress`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884fdb2db308332ae7c8ca2b4fc34e2