### PR TITLE
Fix plan redirect button

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -32,8 +32,8 @@ function DashboardV2() {
           title="No Goals Yet"
           description="Head over to your plan and add a goal to get started"
         >
-          <Button asChild colorPalette="cyan">
-            <NextLink href="/plan">Go to Plan</NextLink>
+          <Button as={NextLink} href="/plan" colorPalette="cyan">
+            Go to Plan
           </Button>
         </EmptyState>
       </Center>

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -65,8 +65,8 @@ function NewPlan() {
           title={created ? 'Plan created' : 'Plan in progress'}
           description={created ? 'Your plan has been created successfully.' : 'You already have a plan in progress.'}
         >
-          <Button asChild colorPalette="cyan">
-            <NextLink href="/plan">Go to Plan</NextLink>
+          <Button as={NextLink} href="/plan" colorPalette="cyan">
+            Go to Plan
           </Button>
         </EmptyState>
       </Center>

--- a/src/app/plan/page.tsx
+++ b/src/app/plan/page.tsx
@@ -121,8 +121,8 @@ function PlanV2Page() {
           size="lg"
           description="Create a new plan to get started"
         >
-          <Button asChild colorPalette="cyan">
-            <NextLink href="/new">Create Plan</NextLink>
+          <Button as={NextLink} href="/new" colorPalette="cyan">
+            Create Plan
           </Button>
         </EmptyState>
       </Center>
@@ -318,8 +318,8 @@ function PlanV2Page() {
               <p className="text-muted-foreground mb-4">
                 View charts and trends of your indicators to see your progress over time.
               </p>
-              <Button asChild colorPalette="black" className="mt-auto">
-                <NextLink href="/progress">View Progress</NextLink>
+              <Button as={NextLink} href="/progress" colorPalette="black" className="mt-auto">
+                View Progress
               </Button>
             </Card.Root>
 
@@ -329,8 +329,8 @@ function PlanV2Page() {
               <p className="text-muted-foreground mb-4">
                 Browse pre-built goal templates for common objectives and add them to your plan.
               </p>
-              <Button asChild colorPalette="black" className="mt-auto">
-                <NextLink href="/templates">Browse Templates</NextLink>
+              <Button as={NextLink} href="/templates" colorPalette="black" className="mt-auto">
+                Browse Templates
               </Button>
             </Card.Root> */}
             {/* 
@@ -340,8 +340,8 @@ function PlanV2Page() {
               <p className="text-muted-foreground mb-4">
                 Get intelligent suggestions for goals, strategies, and indicators based on your plan.
               </p>
-              <Button asChild colorPalette="black" className="mt-auto">
-                <NextLink href="/suggestions">Get Suggestions</NextLink>
+              <Button as={NextLink} href="/suggestions" colorPalette="black" className="mt-auto">
+                Get Suggestions
               </Button>
             </Card.Root> */}
           </div>

--- a/src/app/progress/page.tsx
+++ b/src/app/progress/page.tsx
@@ -112,8 +112,8 @@ export default function TrackerPage() {
           title="No Goals or Actions"
           description="Add goals and actions in your plan to see your progress."
         >
-          <Button asChild colorPalette="cyan">
-            <NextLink href="/plan">Go to Plan</NextLink>
+          <Button as={NextLink} href="/plan" colorPalette="cyan">
+            Go to Plan
           </Button>
         </EmptyState>
       </Center>
@@ -129,8 +129,8 @@ export default function TrackerPage() {
           title="Plan Not Started"
           description="Start your plan or update it in the plan page."
         >
-          <Button asChild colorPalette="cyan">
-            <NextLink href="/plan">Go to Plan</NextLink>
+          <Button as={NextLink} href="/plan" colorPalette="cyan">
+            Go to Plan
           </Button>
         </EmptyState>
       </Center>


### PR DESCRIPTION
## Summary
- fix button links to use Next.js routing

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a5376c588332ad38eef8b4bb8aa6