### PR TITLE
Fix dashboard tasks filtering by week

### DIFF
--- a/src/app/dashboard/GoalCard.tsx
+++ b/src/app/dashboard/GoalCard.tsx
@@ -30,7 +30,13 @@ export default function GoalCard({ goal, sequence, disabled }: GoalCardProps) {
   const [loadingToggle, setLoadingToggle] = useState<{actionId: string, index: number} | null>(null)
 
   const goalStrategies = useMemo(
-    () => strategies.filter((s) => s.strategy.goalId === goal.id && s.sequence === sequence),
+    () =>
+      strategies.filter(
+        (s) =>
+          s.strategy.goalId === goal.id &&
+          s.sequence === sequence &&
+          s.strategy.weeks.includes(sequence.toString())
+      ),
     [strategies, goal.id, sequence]
   )
   const orderedStrategies: StrategyHistoryExtended[] = getOrderedStrategies(goal.planId, goalStrategies)


### PR DESCRIPTION
## Summary
- ensure strategies displayed in GoalCard belong to the active week

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts during Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_688c9ea293fc833286e85bde7358541e